### PR TITLE
use decode fn from quick_xml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Reizner Evgeniy <razrfalcon@gmail.com>"]
 [dev-dependencies]
 bencher = "0.1"
 xml-rs = "0.6.0"
-quick-xml = "0.8.0"
+quick-xml = "0.8.1"
 xml5ever = "0.8.0"
 sxd-document = "0.2.2"
 


### PR DESCRIPTION
Make quick_xml decode non utf8 files.

From your example in reddit:
```
$ cargo run --example quick_xml data/ISO-8859-5.xml
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/examples/quick_xml data/ISO-8859-5.xml`
  Text: ""
Declaration
  version="1.0"
  encoding="ISO-8859-5"
  standalone="yes"
  Text: "\n"
Start: text
    Text: "\n    Текст\n"
End: text
  Text: "\n"
```