### PR TITLE
Clear the buffer in quick_xml loop

### DIFF
--- a/benches/xml.rs
+++ b/benches/xml.rs
@@ -57,6 +57,7 @@ fn quick_xml_parse(text: &str) {
             Ok((_, quick_xml::events::Event::Eof)) => break,
             _ => {}
         }
+        buf.clear();
     }
 }
 


### PR DESCRIPTION
This should avoid some allocation, in particular for large xmls.